### PR TITLE
React to server.json changes for ChefInterval, 0.9.1

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -9,7 +9,7 @@ var target = Argument("target", "FullBuild");
 var configuration = Argument("configuration", "Debug");
 var buildNumber = Argument("buildNumber", "0");
 
-var version = "0.9.0." + buildNumber;
+var version = "0.9.1." + buildNumber;
 
 var cafeDirectory = Directory("./src/cafe");
 var cafeProject = cafeDirectory + File("cafe.csproj");

--- a/src/cafe.Updater/cafe.Updater.csproj
+++ b/src/cafe.Updater/cafe.Updater.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <VersionPrefix>0.9.0</VersionPrefix>
+    <VersionPrefix>0.9.1</VersionPrefix>
     <TargetFramework>netcoreapp1.1</TargetFramework>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <DebugType>portable</DebugType>

--- a/src/cafe/Options/Server/CafeServerWindowsService.cs
+++ b/src/cafe/Options/Server/CafeServerWindowsService.cs
@@ -45,11 +45,32 @@ namespace cafe.Options.Server
                     }
                 });
 
+            Initialize();
+
+            ReactToChangesToServerConfiguration();
+
+            _webHost.Start();
+        }
+
+        private static void ReactToChangesToServerConfiguration()
+        {
+            FileSystemWatcher watcher = new FileSystemWatcher(".") {Filter = "server.json"};
+            watcher.Changed += OnServerConfigurationChanged;
+            watcher.EnableRaisingEvents = true;
+        }
+
+        private static void OnServerConfigurationChanged(object sender, FileSystemEventArgs args)
+        {
+            Presenter.ShowMessage("Server configuration changed, so resetting Chef Interval", Logger);
+            ServerSettings.Reload();
+            Initialize();
+        }
+
+        private static void Initialize()
+        {
             Initialize(StructureMapResolver.Container.GetInstance<RunChefJob>(), ServerSettings.Instance.ChefInterval,
                 StructureMapResolver.Container.GetInstance<ITimerFactory>(),
                 StructureMapResolver.Container.GetInstance<IClock>());
-
-            _webHost.Start();
         }
 
         public static void Initialize(RunChefJob runChefJob, int chefIntervalInSeconds, ITimerFactory timerFactory,

--- a/src/cafe/Server/Jobs/RunChefJob.cs
+++ b/src/cafe/Server/Jobs/RunChefJob.cs
@@ -1,12 +1,15 @@
 ﻿using System;
 using cafe.Chef;
 using cafe.Shared;
+using NLog;
 using NodaTime;
 
 namespace cafe.Server.Jobs
 {
     public class RunChefJob : Job
     {
+        private static readonly Logger Logger = LogManager.GetLogger(typeof(RunChefJob).FullName);
+
         private readonly IChefRunner _chefRunner;
         private readonly IClock _clock;
         private RunPolicy _runPolicy;
@@ -23,6 +26,12 @@ namespace cafe.Server.Jobs
             get { return _runPolicy; }
             set
             {
+                if (_runPolicy != null)
+                {
+                    Logger.Debug($"Removing policy {_runPolicy} from Chef");
+                    _runPolicy.Due -= ProcessPolicyDue;
+                }
+                Logger.Debug($"Adding policy {value} for Chef");
                 value.Due += ProcessPolicyDue;
                 _runPolicy = value;
             }

--- a/src/cafe/ServerSettings.cs
+++ b/src/cafe/ServerSettings.cs
@@ -1,17 +1,48 @@
 ﻿using cafe.CommandLine;
+using NLog;
 
 namespace cafe
 {
     public class ServerSettings
     {
+        private static readonly Logger Logger = LogManager.GetLogger(typeof(ServerSettings).FullName);
+
+        /// <summary>
+        /// Gets or sets the Chef Interval
+        /// </summary>
+        /// <remarks>when this changes, the server does not need to be restarted to adjust to the change</remarks>
         public int ChefInterval { get; set; }
+        /// <summary>
+        // Gets or sets the port that the application listens on
+        /// </summary>
+        /// <remarks>when changing the port, you must restart the service</remarks>
         public int Port { get; set; } = DefaultPort;
+        /// <summary>
+        /// Gets or sets the folder that chef is installed on.
+        /// </summary>
+        /// <remarks>
+        /// It is assumed that this is the folder cafe is installed on as well.
+        /// Also, when this setting changes, the system will respond the next time chef is run.
+        /// This should rarely if ever change, and only at installation.
+        /// </remarks>
         public string InstallRoot { get; set; } = @"C:";
+        /// <summary>
+        /// Gets or sets the folder that the cafe.Updater is installed in
+        /// </summary>
+        /// <remarks>this should only change in a testing scenario</remarks>
         public string UpdaterDirectory { get; set; } = "updater";
 
         public const int DefaultPort = 59320;
 
-        public static readonly ServerSettings Instance = SettingsReader.Read<ServerSettings>("Server", "server.json");
+        private static ServerSettings _instance;
+
+        public static ServerSettings Instance => _instance ?? (_instance = SettingsReader.Read<ServerSettings>("Server", "server.json"));
+
+        public static void Reload()
+        {
+            Logger.Debug("Reloading server settings the next time they are accessed");
+            _instance = null;
+        }
 
         public override string ToString()
         {

--- a/src/cafe/cafe.csproj
+++ b/src/cafe/cafe.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
-    <VersionPrefix>0.9.0</VersionPrefix>
+    <VersionPrefix>0.9.1</VersionPrefix>
     <TargetFramework>netcoreapp1.1</TargetFramework>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <DebugType>portable</DebugType>

--- a/test/cafe.IntegrationTest/cafe.IntegrationTest.csproj
+++ b/test/cafe.IntegrationTest/cafe.IntegrationTest.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <VersionPrefix>0.9.0</VersionPrefix>
+    <VersionPrefix>0.9.1</VersionPrefix>
     <TargetFramework>netcoreapp1.1</TargetFramework>
     <DebugType>portable</DebugType>
     <AssemblyName>cafe.IntegrationTest</AssemblyName>

--- a/test/cafe.Test/Server/Jobs/RunChefJobTest.cs
+++ b/test/cafe.Test/Server/Jobs/RunChefJobTest.cs
@@ -129,6 +129,22 @@ namespace cafe.Test.Server.Jobs
             wasRunReady.Should().BeTrue("because the previous run already ran, we're ready to run again");
         }
 
+        [Fact]
+        public void Due_ShouldNotFireWhenAnotherPolicyIsUsed()
+        {
+            var policy = new FakeRunPolicy();
+            var runChefJob = CreateRunChefJob(runPolicy: policy);
+
+            bool wasRunReady = false;
+            runChefJob.RunReady += (sender, run) => wasRunReady = true;
+
+            runChefJob.RunPolicy = new FakeRunPolicy();
+
+            policy.FireDue();
+
+            wasRunReady.Should().BeFalse("because a different policy is in place now");
+        }
+
 
     }
 }

--- a/test/cafe.Test/cafe.Test.csproj
+++ b/test/cafe.Test/cafe.Test.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <VersionPrefix>0.9.0</VersionPrefix>
+    <VersionPrefix>0.9.1</VersionPrefix>
     <TargetFramework>netcoreapp1.1</TargetFramework>
     <DebugType>portable</DebugType>
     <AssemblyName>cafe.Test</AssemblyName>


### PR DESCRIPTION
This addresses #25. the ChefInterval is the only thing that needs to change based on a server.json change. Changes to the others will not be supported.